### PR TITLE
Clean manifest and migrate MultiDex to AndroidX

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ android {
         versionName "1.3"
         multiDexEnabled true
     }
-    buildTypes {2
+    buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
@@ -27,5 +27,5 @@ dependencies {
     compile 'com.android.support:design:23.4.0'
     compile 'com.github.bloder:magic:1.1'
     compile 'com.google.android.gms:play-services:9.4.0'
-    compile 'com.android.support:multidex:1.0.0'
+    compile 'androidx.multidex:multidex:2.0.1'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.akarshan.drivelert"
-    android:versionCode="2">
-
-    <uses-sdk
-        android:minSdkVersion="9"
-        android:targetSdkVersion="22" />
+    package="com.example.akarshan.drivelert">
 
     <uses-feature android:name="android.hardware.camera" />
     <uses-permission android:name="android.permission.CAMERA" />
@@ -14,21 +9,24 @@
     <application
         android:allowBackup="true"
         android:largeHeap="true"
-        android:name="android.support.multidex.MultiDexApplication"
+        android:name="androidx.multidex.MultiDexApplication"
         android:icon="@drawable/l"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
             android:name=".FaceTrackerActivity"
-            android:screenOrientation="portrait" />
+            android:screenOrientation="portrait"
+            android:exported="false" />
         <activity
             android:name=".help"
-            android:screenOrientation="portrait" />
+            android:screenOrientation="portrait"
+            android:exported="false" />
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name"
-            android:theme="@style/AppTheme.NoActionBar">
+            android:theme="@style/AppTheme.NoActionBar"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -37,9 +35,14 @@
         </activity>
         <activity
             android:name=".monitor_menu"
-            android:screenOrientation="portrait" />
-        <activity android:name=".end" />
-        <activity android:name=".contactus" />
+            android:screenOrientation="portrait"
+            android:exported="false" />
+        <activity
+            android:name=".end"
+            android:exported="false" />
+        <activity
+            android:name=".contactus"
+            android:exported="false" />
     </application>
 
 </manifest>


### PR DESCRIPTION
## Summary
- Remove `<uses-sdk>` and versionCode from manifest to rely on Gradle configuration
- Switch to `androidx.multidex.MultiDexApplication` and update MultiDex dependency
- Declare `android:exported` on all activities for API 31+

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68b35e0077f08330a031cccef46940ad